### PR TITLE
Add constants for max and min integers

### DIFF
--- a/constants/integers.go
+++ b/constants/integers.go
@@ -1,0 +1,7 @@
+package constants
+
+// https://stackoverflow.com/a/6878625
+const MaxUint = ^uint(0)
+const MinUint = 0
+const MaxInt = int(MaxUint >> 1)
+const MinInt = -MaxInt - 1


### PR DESCRIPTION
Go supplies constants for max/min of specific bit size integer types (e.g. `int64`) but not for the variable-sized `int` and `uint` types.